### PR TITLE
Update path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ UMAP and formats them for cbBuild. An example file is on our downloads server:
 
 From Jupyter or Python3, create a data directory with the tab-sep files:
 
-    sys.path.append("cellbrowser/src/cbLib")
+    sys.path.append("cellbrowser/src/cbPyLib")
     import cellbrowser
     # convert to tsv files and create a cellbrowser.conf
     cellbrowser.scanpyToTsv(adata, "scanpyOut", "myDataset")


### PR DESCRIPTION
For the conversion of a `scanpy` object, the readme example uses an incorrect path to the python library (`cbLib`). This corrects it to `cbPyLib`.