### PR TITLE
Update geneinfo.py exception handling to python3

### DIFF
--- a/src/cbPyLib/cellbrowser/geneinfo.py
+++ b/src/cbPyLib/cellbrowser/geneinfo.py
@@ -95,8 +95,8 @@ def lineFileNextRow(inFile):
         fields = string.split(line, "\t", maxsplit=len(headers)-1)
         try:
             rec = Record(*fields)
-        except Exception, msg:
-            logging.error("Exception occured while parsing line, %s" % msg)
+        except Exception as e:
+            logging.error("Exception occured while parsing line, %s" % e)
             logging.error("Filename %s" % fh.name)
             logging.error("Line was: %s" % line)
             logging.error("Does number of fields match headers?")


### PR DESCRIPTION
This line currently throws an error when building it in conda:

```
byte-compiling build/bdist.macosx-10.9-x86_64/egg/cellbrowser/geneinfo.py to geneinfo.cpython-37.pyc
  File "build/bdist.macosx-10.9-x86_64/egg/cellbrowser/geneinfo.py", line 98
    except Exception, msg:
                    ^
SyntaxError: invalid syntax
```

Apparently the `except Exception, e` is python 2 only idiom. Following recommendation from http://python-future.org/compatible_idioms.html#catching-exceptions