### PR TITLE
Add cbSeurat to list of executables

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     'console_scripts': [
         'cbBuild = cellbrowser.cellbrowser:cbBuildCli',
         'cbScanpy = cellbrowser.cellbrowser:cbScanpyCli',
+        'cbSeurat = cellbrowser.seurat:cbSeuratCli',
         'cbTool = cellbrowser.convert:cbToolCli',
         'cbUpgrade = cellbrowser.cellbrowser:cbMake_cli',
         'cbGuessGencode = cellbrowser.guessgenes:cbGuessGencodeCli',


### PR DESCRIPTION
Conda package creation fails on test with:

```
+ which cbSeurat
Tests failed for ucsc-cell-browser-0.4.20-py_0.tar.bz2 - moving package to /Users/pmoreno/miniconda3/conda-bld/broken
```