### PR TITLE
Case for gene_symbols in var from anndata

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -3105,6 +3105,10 @@ def anndataToTsv(ad, matFname, usePandas=False, useRaw=False):
             geneIdObj = var["gene_ids"]
             geneIdAndSyms = zip(geneIdObj.values, geneIdObj.index)
             genes = [x+"|"+y for (x,y) in geneIdAndSyms]
+        else if "gene_symbols" in var:
+            geneIdObj = var['gene_symbols']
+            geneIdAndSyms = zip(geneIdObj.index, geneIdObj.values)
+            genes = [x+"|"+y for (x,y) in geneIdAndSyms]
         else:
             genes = var.index.tolist()
 

--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -3105,7 +3105,7 @@ def anndataToTsv(ad, matFname, usePandas=False, useRaw=False):
             geneIdObj = var["gene_ids"]
             geneIdAndSyms = zip(geneIdObj.values, geneIdObj.index)
             genes = [x+"|"+y for (x,y) in geneIdAndSyms]
-        else if "gene_symbols" in var:
+        elif "gene_symbols" in var:
             geneIdObj = var['gene_symbols']
             geneIdAndSyms = zip(geneIdObj.index, geneIdObj.values)
             genes = [x+"|"+y for (x,y) in geneIdAndSyms]


### PR DESCRIPTION
This PR adds a further case presented by Scanpy where gene symbols are present in a dictionary inside `ad.var['gene_symbols']`, so that Gene symbols get rescued when transforming to CellBrowser objects.