### PR TITLE
Allow commas in cluster names in markers file

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -17,6 +17,7 @@ from distutils import spawn
 from collections import namedtuple, OrderedDict
 from os.path import join, basename, dirname, isfile, isdir, relpath, abspath, getsize, getmtime, expanduser
 from time import gmtime, strftime
+import csv
 
 try:
     # python3
@@ -2462,10 +2463,10 @@ def parseMarkerTable(filename, geneToSym):
     otherHeaders = headers[otherStart:otherEnd]
     logging.debug("Other headers: %s" % otherHeaders)
 
+    reader = csv.reader(ifh, delimiter=sep, quotechar='"')
     data = defaultdict(list)
     otherColumns = defaultdict(list)
-    for line in ifh:
-        row = line.rstrip("\r\n").split(sep)
+    for row in reader:
         clusterName = row[clusterIdx]
         geneId = row[geneIdx]
         scoreVal = float(row[scoreIdx])


### PR DESCRIPTION
Since we have clusters with commas, and since this markers parsing code does not really follow the `csv` format, I thought I'd improve it.
Probably, this is not the only place that needs change if I really want to have cluster names with commas, but it's the first one that broke down : )