### PR TITLE
Fix #170

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -4166,8 +4166,9 @@ def findRoot(inDir=None):
 def resolveOutDir(outDir):
     """ user can define mapping e.g. {"alpha" : "/usr/local/apache/htdocs-cells"} in ~/.cellbrowser.conf """
     confDirs = getConfig("outDirs")
-    if outDir in confDirs:
-        outDir = confDirs[outDir]
+    if confDirs:
+        if outDir in confDirs:
+            outDir = confDirs[outDir]
     return outDir
 
 def build(confFnames, outDir, port=None, doDebug=False, devMode=False, redo=None):


### PR DESCRIPTION
Check for `None` condition when `outDirs` is not defined in the config. See #170 for more details on when this error occurs