### PR TITLE
Fix open dataset for plain datasets, fix Esc closing for open dataset…

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -932,7 +932,7 @@ var cellbrowser = function() {
 
         let doFaceting = false;
         let filtList = [];
-        if (openDsInfo.parents === undefined) {
+        if (openDsInfo.parents === undefined && openDsInfo.datasets !== undefined) {
             //noteLines.push("<span>Filter:</span>");
             let bodyParts = getBodyParts(openDsInfo.datasets);
             if (bodyParts.length!==0) {
@@ -1055,7 +1055,9 @@ var cellbrowser = function() {
             changeUrl({"ds":openDatasetName});
         });
 
+        var focused = document.activeElement;
         var scroller = $("#tpDatasetList").overlayScrollbars({ });
+        $(focused).focus();
 
 
         $("#tabLink1").tab("show");


### PR DESCRIPTION
… dialog

In out installation there's no `openDsInfo.datasets` field, so when I hit `o` I get this error in the console:
```
cellBrowser.js?01ccf2da80:786 Uncaught TypeError: Cannot read property 'length' of undefined
    at getBodyParts (cellBrowser.js?01ccf2da80:786)
    at openDatasetDialog (cellBrowser.js?01ccf2da80:937)
    at cellBrowser.js?01ccf2da80:4851
    at f (mousetrap.min.js?2d8a3d9435:5)
    at c.h._handleKey (mousetrap.min.js?2d8a3d9435:7)
    at c.handleKey (mousetrap.min.js?2d8a3d9435:10)
    at HTMLDocument.d (mousetrap.min.js?2d8a3d9435:5)
```
To fix that I skip this bodyParts thing if there's no such property.

The focus manipulations are to close Open dataset dialog with Esc—didn't work for me without this fix.