### PR TITLE
Fix tooltip update on select changes

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -5181,19 +5181,21 @@ var cellbrowser = function() {
             gLegend.selectionDirection = "none";
             checkbox.html("&#9746;");
             // from https://stackoverflow.com/questions/9501921/change-twitter-bootstrap-tooltip-content-on-click
-            checkbox.attr('title', "unselect all checkboxes below")
-                .bsTooltip('fixTitle')
-                .data('bs.tooltip')
-                .$tip.find('.tooltip-inner')
+            checkbox.attr('title', "unselect all checkboxes below");
+            var tip = checkbox.bsTooltip('fixTitle').data('bs.tooltip').$tip;
+            if (tip) {
+                tip.find('.tooltip-inner')
                 .text("unselect all checkboxes below");
+            }
         } else if (gLegend.selectionDirection == "none" && selected === 0) {
             gLegend.selectionDirection = "all";
             checkbox.html("&#9745;");
-            checkbox.attr('title', "select all checkboxes below")
-                .bsTooltip('fixTitle')
-                .data('bs.tooltip')
-                .$tip.find('.tooltip-inner')
+            checkbox.attr('title', "select all checkboxes below");
+            var tip = checkbox.bsTooltip('fixTitle').data('bs.tooltip').$tip;
+            if (tip) {
+                tip.find('.tooltip-inner')
                 .text("select all checkboxes below");
+            }
         }
     }
 


### PR DESCRIPTION
In this commit https://github.com/maximilianh/cellBrowser/commit/313a969831fc140b9c06ad88c2dfcf883d0ad289#diff-fabc9ba7f3a30426c8a51d67788c32dbR5185

I introduced a bug: when selection changes, it tries to update the tooltip label, and if label wasn't ready yet, then `$tip` would be undefined and the code gave an exception.
Now I explicitly check if `$tip` is ready.