### PR TITLE
When reading mtx, produce float32 values, consistent with .tsv.gz. 

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -1354,7 +1354,7 @@ class MatrixMtxReader:
 
             if i%1000==0:
                 logging.info("%d genes written..." % i)
-            arr = mat.getrow(i).toarray()
+            arr = mat.getrow(i).toarray().astype("float32")
             yield (geneId, geneSym, arr)
 
 class MatrixTsvReader:


### PR DESCRIPTION
Fixes #183