### PR TITLE
Fix updating metadata

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -4649,7 +4649,7 @@ var cellbrowser = function() {
             }
 
             htmls.push("<div class='tpMetaValue' style='width:"+(metaBarWidth-2*metaBarMargin)+"px"+styleAdd+
-                "' data-field-name='"+metaInfo.name+"'>&nbsp;</div>");
+                "' data-field-name='"+metaInfo.name+"' id='tpMeta_" + i + "'>&nbsp;</div>");
             htmls.push("</div>"); // tpMetaBox
         }
         htmls.push("<div style='background-color:white; float:right' id='tpMetaNote' style='display:none; height:1em'></div>");


### PR DESCRIPTION
The metadata on the left does not update on hover anymore.

This was broken with this commit: https://github.com/mxposed/cellBrowser/commit/943a949a6ded0153ff7f30305f5696b5cb2134f1#diff-fc1220debf159105733cec0613bcbd64cf7f7e8d71014162826c9836cabb9bcbL4518

I add back the `id` attribute to those nodes