### PR TITLE
Show meta values with UTF-8 characters

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cbData.js
@@ -39,7 +39,7 @@ var cbUtil = (function () {
             "url" : url, 
             type : "GET",
             dataType : "json",
-            mimeType : 'text/plain; charset=x-user-defined', // for local files, avoids errors
+            //mimeType : 'text/plain; charset=x-user-defined', // for local files, avoids errors
             success: function(data) {
                 onSuccess(data);
             },
@@ -129,7 +129,7 @@ var cbUtil = (function () {
 
             var dataLen = binData.byteLength;
             if (!dataLen)
-                dataLen = binData.length;
+                dataLen = new Blob([binData]).size;;
 
             if (dataLen < expLength)
                 alert("internal error cbData.js: chunk is too small. Does the HTTP server really support byte range requests?");


### PR DESCRIPTION
Fixes #199 

MimeType line helps with displaying the metadata on the right correctly (at least on my setup).

The Blob line measures text size in bytes instead of UTF-8 characters as was before