### PR TITLE
Draw violin plot asynchronously, speeds up expression display

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -2717,10 +2717,13 @@ var cellbrowser = function() {
         if (yLabel!==null)
             optDict.scales = { yAxes: [{ scaleLabel: { display: true, labelString: yLabel} }] };
 
-	window.violinChart = new Chart(ctx, {
-	    type: 'violin',
-	    data: boxplotData,
-	    options: optDict});
+        window.setTimeout(function() {
+            window.violinChart = new Chart(ctx, {
+                type: 'violin',
+                data: boxplotData,
+                options: optDict
+            });
+        }, 10);
         console.timeEnd("violinDraw");
     }
 


### PR DESCRIPTION
On a big dataset (~350k cells) the violin plot chart js function takes ~3 seconds to draw.
I put this in a `setTimeout` call, to speed up the refreshing of the UI.

On small datasets the delay is almost unnoticeable.

Please, let me know what you think