### PR TITLE
Show pct of category in meta histogram

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/cellBrowser.js
@@ -4163,7 +4163,7 @@ var cellbrowser = function() {
         htmls.push("<div class='tpMetaTipPerc'>"+(100*valFrac).toFixed(1)+"%</div>");
         htmls.push("<div class='tpMetaTipName'>"+valStr);
         if (valFracCategory !== undefined) {
-            htmls.push(" <small>(" + (100 * valFracCategory).toFixed(1) + "% of it)</small>");
+            htmls.push(" <small>(" + (100 * valFracCategory).toFixed(1) + "% of all cells with this value)</small>");
         }
         htmls.push("</div>");
         //htmls.push("<span class='tpMetaTipCount'>"+valCount+"</span>");


### PR DESCRIPTION
When you hover on a meta field with selection, it shows percentage of a given category that is selected after each category.

For instance:
![Screen Shot 2020-12-29 at 18 25 27](https://user-images.githubusercontent.com/57878/103322309-49e47b80-4a03-11eb-9623-6f9222849a6d.png)

So that you know not only how the selected cells distribute over this field, but also which proportion of those categories are covered