### PR TITLE
Makes sure cbBuildCli exits with an error code if failed

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -4575,7 +4575,7 @@ def cbBuildCli():
         else:
             build(confFnames, outDir, port, redo=options.redo)
     except:
-        logging.error("Unexpected error:", sys.exc_info()[0])
+        logging.error("Unexpected error: %s" % sys.exc_info()[0])
         sys.exit(1)
 
 def readMatrixAnndata(matrixFname, samplesOnRows=False, genome="hg38"):

--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -4566,13 +4566,17 @@ def cbBuildCli():
     #onlyMeta = options.onlyMeta
     port = options.port
 
-    if options.recursive:
-        confFnames = glob.glob("*/cellbrowser.conf")
-        for cf in confFnames:
-            logging.info("Recursive mode: processing %s" % cf)
-            build(cf, outDir, redo=options.redo)
-    else:
-        build(confFnames, outDir, port, redo=options.redo)
+    try:
+        if options.recursive:
+            confFnames = glob.glob("*/cellbrowser.conf")
+            for cf in confFnames:
+                logging.info("Recursive mode: processing %s" % cf)
+                build(cf, outDir, redo=options.redo)
+        else:
+            build(confFnames, outDir, port, redo=options.redo)
+    except:
+        logging.error("Unexpected error:", sys.exc_info()[0])
+        sys.exit(1)
 
 def readMatrixAnndata(matrixFname, samplesOnRows=False, genome="hg38"):
     " read an expression matrix and return an adata object. Supports .mtx, .h5 and .tsv (not .tsv.gz) "


### PR DESCRIPTION
I have seen many cases on our Galaxy instances where cbBuild fails without an error code, which means that Galaxy thinks that the process finished correctly. This should catch any such cases.