### PR TITLE
Drawing labels in js

### DIFF
--- a/src/cbPyLib/cellbrowser/cbWeb/js/maxPlot.js
+++ b/src/cbPyLib/cellbrowser/cbWeb/js/maxPlot.js
@@ -1089,8 +1089,6 @@ function MaxPlot(div, top, left, width, height, args) {
        self.calcRadius();
 
        self.coords.px = scaleCoords(self.coords.orig, borderMargin, self.port.zoomRange, self.canvas.width, self.canvas.height);
-       if (self.coords.labels!==undefined && self.coords.labels!==null)
-           self.coords.pxLabels = scaleLabels(self.coords.labels, self.port.zoomRange, borderMargin, self.canvas.width, self.canvas.height);
        if (self.coords.lines)
            self.coords.pxLines = scaleLines(self.coords.lines, self.port.zoomRange, self.canvas.width, self.canvas.height);
     }
@@ -1222,6 +1220,12 @@ function MaxPlot(div, top, left, width, height, args) {
        self.scaleData();
     };
 
+    this.setLabelCoords = function(labelCoords) {
+        var prevLabels = self.coords.labels.length > 0;
+        self.coords.labels = labelCoords;
+        return prevLabels;
+    };
+
     this.setColorArr = function(colorArr) {
     /* set the color array, one array with one index per coordinate */
        self.col.arr = colorArr;
@@ -1306,7 +1310,7 @@ function MaxPlot(div, top, left, width, height, args) {
         console.timeEnd("draw");
 
         if (self.doDrawLabels===true && self.coords.labels!==null) {
-            self.coords.labelBbox = drawLabels(self.ctx, self.coords.pxLabels, self.canvas.width, self.canvas.height, zoomFact);
+            self.redrawLabels();
         }
 
         if (self.coords.pxLines) {
@@ -1317,6 +1321,23 @@ function MaxPlot(div, top, left, width, height, args) {
 
         if (self.childPlot)
             self.childPlot.drawDots();
+    };
+
+    this.redrawLabels = function() {
+        self.coords.pxLabels = scaleLabels(
+            self.coords.labels,
+            self.port.zoomRange,
+            self.port.radius,
+            self.canvas.width,
+            self.canvas.height
+        );
+        self.coords.labelBbox = drawLabels(
+            self.ctx,
+            self.coords.pxLabels,
+            self.canvas.width,
+            self.canvas.height,
+            self.port.zoomFact
+        );
     };
 
     this.cellsAtPixel = function(x, y) {


### PR DESCRIPTION
Started implementing #187 

Here's the first take:

- [x] label coords are still loaded in JS, but not passed to the renderer
- [x] after coords are loaded, label coords are computed in JS and set to the renderer
- [x] currently label coords are computed as median coordinates of all dots (in python the logic is different, see below)
- [x] added UI combobox field to select which metadata field to draw labels for
- [x] no marker genes are drawn or attempted if current label field is not the config label field
- [x] support select by alt-click on cluster labels

TODO:
- [ ] figure out what to do with heatmap (use config label field always or redraw based on UI label field)
- [ ] save and load UI label field into URL parameter

Algorithm for label coordinates:
In python a mean coordinate is computed for each cluster, then bottom 70% of dots are selected based on distance to cluster and the mean is recomputed. It's possibly too heavy to do in JS, but I haven't tried.
I implemented the mean coordinate, it didn't look good, so I switched to the median coordinate, which currently looks nice.

I'm open to any feedback, please advise how to continue