### PR TITLE
Fixed a typo

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -1920,7 +1920,7 @@ def exprEncode(geneDesc, exprArr, matType):
         if matType=="float":
             exprArr = exprArr.astype("float32")
         elif matType=="int":
-            exprStr = exprArr.astype("uint32")
+            exprArr = exprArr.astype("uint32")
         else:
             assert(False) # internal error
         exprStr = exprArr.tobytes()


### PR DESCRIPTION
This fixes an issue I noticed when noticed that expression in cellbrowser did not match the output of FeaturePlot of Seurat. 
In my case, `exprArr` had `int64` type, it was not converted to `uint32` and consequently the encoded string `exprStr` was twice as long. But only the first half was received in JS by `cbData.js::gunzipAndConvert`, leading to many zeros in the decoded array.

I assume this is a typo.