### PR TITLE
python >= 3.9 compatibility (tostring -> tobytes)

### DIFF
--- a/src/cbPyLib/cellbrowser/cellbrowser.py
+++ b/src/cbPyLib/cellbrowser/cellbrowser.py
@@ -1923,8 +1923,11 @@ def exprEncode(geneDesc, exprArr, matType):
             arrType = "L"
         else:
             assert(False) # internal error
-
-        exprStr = array.array(arrType, exprArr).tostring()
+        
+        if sys.version_info >= (3, 2):
+            exprStr = array.array(arrType, exprArr).tobytes()
+        else:
+            exprStr = array.array(arrType, exprArr).tostring()
         minVal = min(exprArr)
 
     if isPy3:


### PR DESCRIPTION
The following error occurs when calling `cbBuild` with python v.3.10:
>INFO:root:Auto-detect: Numbers in matrix are of type 'float'
ERROR:root:Unexpected error: (<class 'AttributeError'>, AttributeError("'array.array' object has no attribute 'tostring'"), <traceback object at 0x103f1ffc0>)
Traceback (most recent call last):
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 4783, in cbBuildCli
    build(confFnames, outDir, port, redo=options.redo)
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 4598, in build
    convertDataset(inDir, inConf, outConf, datasetDir, redo)
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 3955, in convertDataset
    convertExprMatrix(inConf, outMatrixFname, outConf, sampleNames, geneToSym, datasetDir, needFilterMatrix)
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 3297, in convertExprMatrix
    matType = matrixToBin(outMatrixFname, geneToSym, binMat, binMatIndex, discretBinMat, discretMatrixIndex, metaSampleNames, matType=matType, genesAreRanges=genesAreRanges)
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 2052, in matrixToBin
    exprStr, minVal = exprEncode(geneId, exprArr, matType)
  File "/Users/kriemo/.local/pipx/venvs/cellbrowser/lib/python3.10/site-packages/cellbrowser/cellbrowser.py", line 1934, in exprEncode
    exprStr = array.array(arrType, exprArr).tostring()
AttributeError: 'array.array' object has no attribute 'tostring'
>

The `tostring()` method for `array.array` objects has been removed in python >= v3.9. This PR substitutes in the alias method `tobytes()`, which fixes the error, and is backwards compatible with python >= v3.2. 

https://docs.python.org/3.9/whatsnew/3.9.html#removed